### PR TITLE
Add test job to fetch_flyers workflow

### DIFF
--- a/.github/workflows/fetch_flyers.yml
+++ b/.github/workflows/fetch_flyers.yml
@@ -9,7 +9,20 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: python -m pytest  # or whatever your test command is
+
   fetch:
+    needs: test   # only runs if test passes
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request updates the `.github/workflows/fetch_flyers.yml` workflow to add automated testing before running the fetch job. The main improvement is the introduction of a `test` job that installs dependencies and runs tests, ensuring code quality before proceeding to the fetch step.

Workflow enhancements:

* Added a `test` job that checks out the code, sets up Python 3.12, installs dependencies from `requirements.txt`, and runs tests using `pytest` or the specified test command. (`.github/workflows/fetch_flyers.yml`, [.github/workflows/fetch_flyers.ymlR12-R25](diffhunk://#diff-31c639d3023c9871d63af7f08251eeb0e1f9a00946911b078532b88bb4a14110R12-R25))
* Updated the `fetch` job to depend on the `test` job, so it only runs if the tests pass. (`.github/workflows/fetch_flyers.yml`, [.github/workflows/fetch_flyers.ymlR12-R25](diffhunk://#diff-31c639d3023c9871d63af7f08251eeb0e1f9a00946911b078532b88bb4a14110R12-R25))