### PR TITLE
Fix deal duplication in deal listings

### DIFF
--- a/frontend/src/stores/deals.js
+++ b/frontend/src/stores/deals.js
@@ -131,6 +131,18 @@ export const useDealsStore = defineStore('deals', () => {
                (d.brand  ?? '').toLowerCase().includes(q)
       })
       .sort((a, b) => (b.deal_score ?? 0) - (a.deal_score ?? 0))
+      // Deduplicate: same chain + same product name + same price = same deal.
+      // Keeps the highest-scored row (first after sort) when multiple stores
+      // or flyer regions produce identical-looking entries.
+      .filter((() => {
+        const seen = new Set()
+        return d => {
+          const key = `${d.store_chain}\x00${d.name_en ?? d.name_fr ?? ''}\x00${d.sale_price ?? ''}`
+          if (seen.has(key)) return false
+          seen.add(key)
+          return true
+        }
+      })())
       .slice(0, searchQuery.value.trim() ? Infinity : 50)
   })
 

--- a/pipeline/deal_scorer.py
+++ b/pipeline/deal_scorer.py
@@ -599,6 +599,7 @@ def _score_row(
         "price_unit": obs.get("price_unit"),
         "promo_type": obs.get("promo_type"),
         "image_url": obs.get("image_url"),
+        "is_multi_product": bool(obs.get("is_multi_product", False)),
     }
 
 
@@ -657,6 +658,7 @@ def _output_schema():
             ("price_unit", pa.string()),
             ("promo_type", pa.string()),
             ("image_url", pa.string()),
+            ("is_multi_product", pa.bool_()),
         ]
     )
 

--- a/scripts/export_frontend_data.py
+++ b/scripts/export_frontend_data.py
@@ -53,6 +53,7 @@ KEEP_FIELDS = [
     "confidence", "confidence_label",
     "category_l1", "category_l2",
     "image_url",
+    "is_multi_product",
 ]
 
 
@@ -345,6 +346,11 @@ def _export_scores() -> None:
             if isinstance(v, float) and math.isnan(v):
                 row[k] = None
         out.append(row)
+
+    # Drop multi-product parent records ("X OR Y" combined entries) — the
+    # individual child records carry the same price/score and are cleaner to
+    # display.  Children have is_multi_product=False so they are kept.
+    out = [r for r in out if not r.get("is_multi_product")]
 
     # Sort best deals first
     out.sort(key=lambda r: r.get("deal_score") or 0, reverse=True)


### PR DESCRIPTION
Implement deduplication logic to ensure that identical deals (same chain, product name, and price) are filtered out, retaining only the highest-scored entry. Additionally, handle multi-product records to improve display clarity.